### PR TITLE
Upgrade to Javacv 1.4 & remove default videoinput preset

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -39,6 +39,6 @@ settings key and use `++=` to append more (if you do not use append, you will en
 
 ```scala
 javaCppPresetLibs ++= Seq(
-  "ffmpeg" -> "3.2.1"
+  "ffmpeg" -> "3.4.1"
 )
 ```

--- a/README.markdown
+++ b/README.markdown
@@ -34,11 +34,22 @@ javaCppPlatform := "android-arm"
 
 For more details, see the [SBT-JavaCPP plugin](https://github.com/bytedeco/sbt-javacpp#customisation)
 
-Also, this plugin only pulls in `opencv` and `videoinput` JavaCPP presets by default. If you wish to add more, use the `javaCppPresetLibs`
+Also, this plugin only pulls in `opencv` JavaCPP preset by default. If you wish to add more, use the `javaCppPresetLibs`
 settings key and use `++=` to append more (if you do not use append, you will end up wiping out the ones this plugin appends by default):
 
 ```scala
 javaCppPresetLibs ++= Seq(
   "ffmpeg" -> "3.4.1"
+)
+```
+
+### Note when upgrading from versions < 1.16:
+
+As of JavaCPP 1.4 `videoinput` is only available for windows, so it's not included by default since sbt-javacv 1.16.
+If you need it, you can add it just like any other JavaCPP preset:
+      
+```scala
+javaCppPresetLibs ++= Seq(
+  "videoinput" -> "0.200"
 )
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -65,4 +65,4 @@ resolvers ++= Seq(
   Resolver.sonatypeRepo("snapshots")
 )
 
-addSbtPlugin("org.bytedeco" % "sbt-javacpp" % "1.11")
+addSbtPlugin("org.bytedeco" % "sbt-javacpp" % "1.12")

--- a/src/main/scala/org/bytedeco/sbt/javacv/Plugin.scala
+++ b/src/main/scala/org/bytedeco/sbt/javacv/Plugin.scala
@@ -37,8 +37,7 @@ object Plugin extends AutoPlugin {
      * List of default JavaCPP preset names and versions that will be added by this plugin
      */
     val libs = Seq(
-      "opencv" -> "3.4.0",
-      "videoinput" -> "0.200"
+      "opencv" -> "3.4.0"
     )
   }
 

--- a/src/main/scala/org/bytedeco/sbt/javacv/Plugin.scala
+++ b/src/main/scala/org/bytedeco/sbt/javacv/Plugin.scala
@@ -25,7 +25,7 @@ object Plugin extends AutoPlugin {
   }
 
   object Versions {
-    val javaCVVersion = "1.3.2"
+    val javaCVVersion = "1.4"
   }
 
   object autoImport {
@@ -37,7 +37,7 @@ object Plugin extends AutoPlugin {
      * List of default JavaCPP preset names and versions that will be added by this plugin
      */
     val libs = Seq(
-      "opencv" -> "3.2.0",
+      "opencv" -> "3.4.0",
       "videoinput" -> "0.200"
     )
   }


### PR DESCRIPTION
Makes only sense after upgrading sbt-javacpp first of course. I have created a [PR for that](https://github.com/bytedeco/sbt-javacpp/pull/16).

As of javaCPP 1.4, `videoinput` seems to be only [available for windows](https://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22org.bytedeco.javacpp-presets%22%20AND%20a%3A%22videoinput%22).
That's causing errors on other platforms so I removed it from the default presets.